### PR TITLE
Update mecab to mecab-python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mecab
+mecab-python3
 neologdn
 bunkai


### PR DESCRIPTION
Need to update mecab to mecab-python3 or installation will throw errors.